### PR TITLE
fix import path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wintermute-cds/golevel7
+module github.com/dshills/golevel7
 
 go 1.12
 


### PR DESCRIPTION
Expected: 
```
$ go get -v ./...
```

Actual:
```
$ go get -v ./...
go: finding github.com/dshills/golevel7 latest
go: github.com/diagnotes/trigger/hl7 imports
        github.com/dshills/golevel7: github.com/dshills/golevel7@v0.0.0-20190325155054-9d32fd2ecf6d: parsing go.mod:
        module declares its path as: github.com/wintermute-cds/golevel7
                but was required as: github.com/dshills/golevel7
```