### PR TITLE
Make indices 1-based, per HL7 spec

### DIFF
--- a/component.go
+++ b/component.go
@@ -20,7 +20,7 @@ func (c *Component) String() string {
 }
 
 func (c *Component) parse(seps *Delimeters) error {
-	r :=  strings.NewReader(string(c.Value))
+	r := strings.NewReader(string(c.Value))
 	i := 0
 	ii := 0
 	for {
@@ -46,10 +46,10 @@ func (c *Component) parse(seps *Delimeters) error {
 
 // SubComponent returns the subcomponent i
 func (c *Component) SubComponent(i int) (*SubComponent, error) {
-	if i >= len(c.SubComponents) {
+	if i > len(c.SubComponents) || i < 1 {
 		return nil, fmt.Errorf("SubComponent out of range")
 	}
-	return &c.SubComponents[i], nil
+	return &c.SubComponents[i-1], nil
 }
 
 func (c *Component) encode(seps *Delimeters) []rune {

--- a/decode.go
+++ b/decode.go
@@ -28,22 +28,22 @@ func readBuf(reader io.Reader) ([]byte, error) {
 		buf := make([]byte, 0, bufCap)
 		n, err := r.Read(buf[:cap(buf)])
 		buf = buf[:n]
-		quit:= false
+		quit := false
 		switch {
 		case err == io.EOF:
 			//log.Printf("->err == io.EOF")
-			superBuf = append(superBuf,buf...)
+			superBuf = append(superBuf, buf...)
 			quit = true
 		case n < bufCap:
 			//log.Printf("->n < bufCap")
-			superBuf = append(superBuf,buf...)
+			superBuf = append(superBuf, buf...)
 			//quit = true
 		case err != nil:
 			//log.Printf("->err != nil")
 			superBuf = nil
 		default:
 			//log.Printf("->default")
-			superBuf = append(superBuf,buf...)
+			superBuf = append(superBuf, buf...)
 		}
 		if quit {
 			break

--- a/decode_test.go
+++ b/decode_test.go
@@ -6,8 +6,8 @@ import (
 )
 
 type my7 struct {
-	FirstName string `hl7:"PID.5.1"`
-	LastName  string `hl7:"PID.5.0"`
+	FirstName string `hl7:"PID.5.2"`
+	LastName  string `hl7:"PID.5.1"`
 }
 
 func TestDecode(t *testing.T) {

--- a/field.go
+++ b/field.go
@@ -58,10 +58,10 @@ func (f *Field) encode(seps *Delimeters) []rune {
 
 // Component returns the component i
 func (f *Field) Component(i int) (*Component, error) {
-	if i >= len(f.Components) {
+	if i > len(f.Components) || i < 1 {
 		return nil, fmt.Errorf("Component out of range")
 	}
-	return &f.Components[i], nil
+	return &f.Components[i-1], nil
 }
 
 // Get returns the value specified by the Location

--- a/message.go
+++ b/message.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"reflect"
-	"strings"
 	"golang.org/x/net/html/charset"
 	"io/ioutil"
+	"reflect"
+	"strings"
 )
 
 // Message is an HL7 message
@@ -20,13 +20,13 @@ type Message struct {
 // NewMessage returns a new message with the v byte value
 func NewMessage(v []byte) *Message {
 	var utf8V []byte
-	if len(v)!=0 {
+	if len(v) != 0 {
 		reader, err := charset.NewReader(bytes.NewReader(v), "text/plain")
 		if err != nil {
 			return nil
 		}
 		utf8V, err = ioutil.ReadAll(reader)
-	}else {
+	} else {
 		utf8V = v
 	}
 	return &Message{
@@ -157,7 +157,7 @@ func (m *Message) parse() error {
 		switch {
 		case ch == eof || (ch == endMsg && m.Delimeters.LFTermMsg):
 			//just for safety: cannot reproduce this on windows
-			safeii:=map[bool]int{true:len(m.Value), false:ii}[ii>len(m.Value)]
+			safeii := map[bool]int{true: len(m.Value), false: ii}[ii > len(m.Value)]
 			v := m.Value[i:safeii]
 			if len(v) > 4 { // seg name + field sep
 				seg := Segment{Value: v}

--- a/message_test.go
+++ b/message_test.go
@@ -1,10 +1,10 @@
 package golevel7
 
 import (
+	"golang.org/x/net/html/charset"
+	"io/ioutil"
 	"os"
 	"testing"
-	"io/ioutil"
-	"golang.org/x/net/html/charset"
 )
 
 func readFile(fname string) ([]byte, error) {
@@ -14,7 +14,7 @@ func readFile(fname string) ([]byte, error) {
 	}
 	defer file.Close()
 
-	reader, err := charset.NewReader(file,"text/plain")
+	reader, err := charset.NewReader(file, "text/plain")
 	if err != nil {
 		return nil, err
 	}

--- a/messagefind_test.go
+++ b/messagefind_test.go
@@ -14,7 +14,7 @@ func TestFind(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	val, err := msg.Find("OBR.4.2")
+	val, err := msg.Find("OBR.4.3")
 	if err != nil {
 		t.Error(err)
 	}
@@ -22,7 +22,7 @@ func TestFind(t *testing.T) {
 		t.Errorf("Expected CPT-4 got %s\n", val)
 	}
 
-	val, err = msg.Find("OBX.3.2")
+	val, err = msg.Find("OBX.3.3")
 	if err != nil {
 		t.Error(err)
 	}
@@ -77,7 +77,7 @@ func TestRepFields(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	vals, err := msg.FindAll("PID.11.0")
+	vals, err := msg.FindAll("PID.11.3")
 	if err != nil {
 		t.Error(err)
 	}

--- a/segment.go
+++ b/segment.go
@@ -1,8 +1,8 @@
 package golevel7
 
 import (
-	"fmt"
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -24,14 +24,14 @@ func (s *Segment) String() string {
 
 func (s *Segment) isMSH() bool {
 	var toCheck []rune
-	if len(s.Value)>=3 {
+	if len(s.Value) >= 3 {
 		toCheck = s.Value[:3]
-	} else if len(s.Fields)!=0{
+	} else if len(s.Fields) != 0 {
 		f, err := s.Field(0)
 		if err != nil {
 			return false
 		}
-		toCheck=f.Value[:3]
+		toCheck = f.Value[:3]
 	} else {
 		return false
 	}


### PR DESCRIPTION
Per the HL7 spec, all numeric indices start with 1, not 0. This PR changes the indexing so that the data location syntax lines up with the spec.